### PR TITLE
Add a IOException block (MediaCodec)

### DIFF
--- a/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/MediaPlayer.java
+++ b/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/MediaPlayer.java
@@ -734,6 +734,8 @@ public class MediaPlayer {
                 interrupt();
             } catch (IllegalStateException e) {
                 Log.e(TAG, "decoder error, too many instances?", e);
+            } catch(IOException e){
+                Log.e(TAG, "decoder error, codec can not be created", e);
             }
 
             if(mAudioPlayback != null) mAudioPlayback.stopAndRelease();


### PR DESCRIPTION
According to the documentation, [MediaCodec `createDecoderByType`](http://developer.android.com/reference/android/media/MediaCodec.html#createDecoderByType%28java.lang.String%29) can throw an `IOException`, if the codec can not be created.

**Build error** (`compileSdkVersion 22`):

``` sh
[batman@batmans_cave ITEC-MediaPlayer-master]$ ./gradlew publishDebugSnapshotPublicationToMavenLocal
:MediaPlayer:compileLint

...

:MediaPlayer:compileDebugJava
/home/batman/build/ITEC-MediaPlayer-master/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/MediaPlayer.java:413: error: unreported exception IOException; must be caught or declared to be thrown
                mVideoCodec = MediaCodec.createDecoderByType(mVideoFormat.getString(MediaFormat.KEY_MIME));
                                                            ^
/home/batman/build/ITEC-MediaPlayer-master/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/MediaPlayer.java:423: error: unreported exception IOException; must be caught or declared to be thrown
                    mAudioCodec = MediaCodec.createDecoderByType(mAudioFormat.getString(MediaFormat.KEY_MIME));

:MediaPlayer:compileDebugJava FAILED

FAILURE: Build failed with an exception.
```
