### PR TITLE
Clean EventHandler on stop

### DIFF
--- a/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/MediaPlayer.java
+++ b/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/MediaPlayer.java
@@ -286,6 +286,7 @@ public class MediaPlayer {
             } catch (InterruptedException e) {
                 Log.e(TAG, "error waiting for playback thread to die", e);
             }
+            mEventHandler.removeCallbacksAndMessages(null);
             mPlaybackThread = null;
         }
         stayAwake(false);


### PR DESCRIPTION
To fix possible crashes when player-related (e.g. onPrepared) callbacks are fired on already stopped player with thread==null.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/protyposis/itec-mediaplayer/12)

<!-- Reviewable:end -->
