### PR TITLE
Update MediaPlayer.java

### DIFF
--- a/MediaPlayer/src/main/java/net/protyposis/android/mediaplayer/MediaPlayer.java
+++ b/MediaPlayer/src/main/java/net/protyposis/android/mediaplayer/MediaPlayer.java
@@ -548,6 +548,7 @@ public class MediaPlayer {
     }
 
     public void stop() {
+        mCurrentPosition = 0;
         if(mPlaybackThread != null) {
             mPlaybackThread.release();
             mPlaybackThread = null;


### PR DESCRIPTION
A little bug here : when the mediaplayer's reset() method is called while playing, the value of mCurrentPosition would not be reset, I need to update the progress of seekbar by the callback of mediaplayer's state change event, so I add one line of code and my problem is sloved.

Thanks for this wonderful implementation!