### PR TITLE
Added proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,17 @@ and serves as an example on how they can be used and extended. It is available f
 [MediaPlayer-Extended Demo](https://play.google.com/store/apps/details?id=at.aau.itec.android.mediaplayerdemo) on the Google Play Store.
 
 
+### Proguard ###
+
+```
+-keep class * implements com.coremedia.iso.boxes.Box {* ; }
+-keep class * implements com.coremedia.iso.fragment.MovieFragmentBox {* ; }
+-dontwarn com.coremedia.iso.boxes.*
+-dontwarn com.googlecode.mp4parser.authoring.tracks.mjpeg.**
+-dontwarn com.googlecode.mp4parser.authoring.tracks.ttml.**
+```
+
+
 Issues & Limitations
 --------------------
 


### PR DESCRIPTION
The default release project will crash without proguard; specifically `MovieFragmentBox` when trying to play a video. Not sure if the other rules are necessary.