### PR TITLE
Fix ImageReader crash when accessing Image buffer

### DIFF
--- a/MediaPlayer/src/main/java/net/protyposis/android/mediaplayer/MediaExtractor.java
+++ b/MediaPlayer/src/main/java/net/protyposis/android/mediaplayer/MediaExtractor.java
@@ -19,6 +19,7 @@ package net.protyposis.android.mediaplayer;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.media.MediaCodec;
+import android.media.MediaCodecInfo.CodecCapabilities;
 import android.media.MediaFormat;
 import android.net.Uri;
 import android.os.Build;
@@ -195,6 +196,8 @@ public class MediaExtractor {
             mediaFormat.setFloat(MEDIA_FORMAT_EXTENSION_KEY_DAR,
                     (float)mediaFormat.getInteger(MediaFormat.KEY_WIDTH)
                             / mediaFormat.getInteger(MediaFormat.KEY_HEIGHT));
+            mediaFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT,
+                    CodecCapabilities.COLOR_FormatYUV420Flexible);
         }
 
         return mediaFormat;


### PR DESCRIPTION
### WHAT
When `setSurface` with a ImageReader surface, the `MediaFormat.KEY_COLOR_FORMAT` has to correspond to ImageReader's format. If not set, some codec will uses default not compatible with `ImageFormat.YUV_420_888` and causes crash similar to https://ittone.ma/ittone/android-jni-detected-error-in-application-non-zero-capacity-for-nullptr-pointer-1/

### Commits
* Fix ImageReader crash when accessing Image buffer by setting `MediaFormat.KEY_COLOR_FORMAT` to `CodecCapabilities.COLOR_FormatYUV420Flexible` corresponding to `ImageFormat.YUV_420_888` for extraction.
